### PR TITLE
qmk firmwareでビルドできなくなっていたので修正

### DIFF
--- a/tone_rev2/keymaps/default/keymap.c
+++ b/tone_rev2/keymaps/default/keymap.c
@@ -23,10 +23,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 /* Rotary encoder settings */
-void encoder_update_user(uint16_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
    if (clockwise) {
         tap_code(KC_UP);    //Rotary encoder clockwise
     } else {
         tap_code(KC_DOWN);  //Rotary encoder Reverse clockwise
     }
+    return true;
 }

--- a/tone_rev2/keymaps/test/keymap.c
+++ b/tone_rev2/keymaps/test/keymap.c
@@ -23,10 +23,11 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
 };
 
 /* Rotary encoder settings */
-void encoder_update_user(uint16_t index, bool clockwise) {
+bool encoder_update_user(uint8_t index, bool clockwise) {
    if (clockwise) {
         tap_code(KC_0);    //Rotary encoder clockwise
     } else {
         tap_code(KC_1);  //Rotary encoder Reverse clockwise
     }
+    return true;
 }


### PR DESCRIPTION
Rotary encoder向けの設定がちょっと古い記述でビルドできなくなっていたので最新のに合わせました。