### PR TITLE
QMKの更新に追従するためにBOOTMAGIC_ENABLEの記載を修正

### DIFF
--- a/tone_rev2/rules.mk
+++ b/tone_rev2/rules.mk
@@ -7,7 +7,7 @@ BOOTLOADER = caterina
 # Build Options
 #   change yes to no to disable
 #
-BOOTMAGIC_ENABLE = lite     # Virtual DIP switch configuration
+BOOTMAGIC_ENABLE = yes      # Virtual DIP switch configuration
 MOUSEKEY_ENABLE = yes       # Mouse keys
 EXTRAKEY_ENABLE = yes       # Audio control and System control
 CONSOLE_ENABLE = no         # Console for debug


### PR DESCRIPTION
QMKが2021/11/27の更新で、BOOTMAGIC_ENABLEにyesもしくはno以外の引数を指定するとコンパイルエラーとなるようになりました。
yesが旧来のliteの意味となったとのことで、そのように記載を修正しました。

cf. https://github.com/qmk/qmk_firmware/pull/15002